### PR TITLE
Correction erreur JS sur le panel

### DIFF
--- a/core/class/myBMW.class.php
+++ b/core/class/myBMW.class.php
@@ -638,7 +638,7 @@ class myBMW extends eqLogic {
 				}
 				$this->checkAndUpdateCmd('trips', json_encode($trips));
 			}
-			else if ($data->status == "TripHistoryNotActive") {
+			else if ($data->status == "TripHistoryNotActive" || $data->status == "NoTripsYet") {
 				$this->checkAndUpdateCmd('drivingStats', json_encode(array()));
 				$this->checkAndUpdateCmd('trips', json_encode(array()));
 			}


### PR DESCRIPTION
Uncaught SyntaxError: JSON.parse: unexpected end of data
sur la commande drivingStats qui n'a pas encore de valeur.
Le log:
Result getLastTrip() : {"status":"NoTripsYet","vin":"WBAkivabien","gcid":"queJ'ai"
